### PR TITLE
fix: new substitution-records created via modal no longer disappear

### DIFF
--- a/src/substitutions/components/settingTab.ts
+++ b/src/substitutions/components/settingTab.ts
@@ -56,8 +56,11 @@ export class SettingTab extends PluginSettingTab {
         this.rendered = true;
     }
 
-    override async hide(): Promise<void> {
-        await this.dataStore.overwriteSubstitutionRecords(
+    override hide(): Promise<void> {
+        this.containerEl.empty();
+        this.rendered = false;
+
+        return this.dataStore.overwriteSubstitutionRecords(
             this.records.map(sr => sr.record)
         );
     }


### PR DESCRIPTION
Records created via the in-editor modal are correctly persisted and not overwritten by stale data in the settings tab. The issue occurred when the settings tab was opened, then a new substitution-record was created via modal, followed by opening the settings tab again, which overwrote the save data with a stale version.